### PR TITLE
Support both jessie and stretch releases

### DIFF
--- a/moonlight.sh
+++ b/moonlight.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+RELEASE=$(lsb_release -a | awk '/^Codename:/ {print $2}')
+
 echo -e "\n****************************************************************"
 echo -e "Welcome to the Moonlight Installer Script for RetroPie v17.10.07"
 echo -e "****************************************************************\n"
@@ -21,11 +23,11 @@ case $NUM in
 		echo -e "\nPHASE ONE: Add Moonlight to Sources List"
 		echo -e "****************************************\n"
 		
-		if grep -q "deb http://archive.itimmer.nl/raspbian/moonlight jessie main" /etc/apt/sources.list; then
+		if grep -q "deb http://archive.itimmer.nl/raspbian/moonlight $RELEASE main" /etc/apt/sources.list; then
 			echo -e "NOTE: Moonlight Source Exists - Skipping"
 		else
 			echo -e "Adding Moonlight to Sources List"
-			echo "deb http://archive.itimmer.nl/raspbian/moonlight jessie main" >> /etc/apt/sources.list
+			echo "deb http://archive.itimmer.nl/raspbian/moonlight $RELEASE main" >> /etc/apt/sources.list
 		fi
 		
 		echo -e "\n**** PHASE ONE Complete!!!! ****"


### PR DESCRIPTION
RetroPi 4.4 moved to stretch, which breaks the script as it adds the wrong source list. This PR dynamically determines the OS and adds the correct source list. This should also let the script work for future releases as well.